### PR TITLE
ENH: setting of remotes not anymore done in get_build_GEOSldas

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -3,32 +3,32 @@ GEOSldas:
 
 env:
   local: ./@env
-  remote: ../ESMA_env.git
+  remote: https://github.com/GEOS-ESM/ESMA_env
   tag: v3.13.0
 
 cmake:
   local: ./@cmake
-  remote: ../ESMA_cmake.git
+  remote: https://github.com/GEOS-ESM/ESMA_cmake
   tag: v3.12.0
 
 ecbuild:
   local: ./@cmake/@ecbuild
-  remote: ../ecbuild.git
+  remote: https://github.com/GEOS-ESM/ecbuild
   tag: geos/v1.2.0
 
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
-  remote: ../GMAO_Shared.git
+  remote: https://github.com/GEOS-ESM/GMAO_Shared
   sparse: ./config/GMAO_Shared.sparse
   tag: v1.5.5
 
 MAPL:
   local: ./src/Shared/@MAPL
-  remote: ../MAPL.git
+  remote: https://github.com/GEOS-ESM/MAPL
   tag: v2.19.0
 
 GEOSgcm_GridComp:
   local: ./src/Components/GEOSldas_GridComp/@GEOSgcm_GridComp
-  remote: ../GEOSgcm_GridComp.git
+  remote: https://github.com/GEOS-ESM/GEOSgcm_GridComp
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse
   tag: v1.15.5


### PR DESCRIPTION
This PR simplifies the GEOSldas compilation script and allows to easily refer in the components.yaml to own branches in forks of GEOS-ESM repositories.