### PR TITLE
ENH: components.yaml referred to 'tag:...' instead of 'branch:...'

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -29,6 +29,6 @@ MAPL:
 
 GEOSgcm_GridComp:
   local: ./src/Components/GEOSldas_GridComp/@GEOSgcm_GridComp
-  remote: https://github.com/GEOS-ESM/GEOSgcm_GridComp
+  remote: https://github.com/sebastian-a-swm/GEOSgcm_GridComp
   branch: v1.15.5_KUL
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse

--- a/components.yaml
+++ b/components.yaml
@@ -30,5 +30,5 @@ MAPL:
 GEOSgcm_GridComp:
   local: ./src/Components/GEOSldas_GridComp/@GEOSgcm_GridComp
   remote: https://github.com/GEOS-ESM/GEOSgcm_GridComp
+  branch: v1.15.5_KUL
   sparse: ./config/GEOSgcm_GridComp_ldas.sparse
-  tag: v1.15.5


### PR DESCRIPTION
We discussed that the change was correct and necessary.